### PR TITLE
Rename `abrupt-comment` error to `abrupt-closing-of-comment`

### DIFF
--- a/tokenizer/escapeFlag.test
+++ b/tokenizer/escapeFlag.test
@@ -18,7 +18,7 @@
 "input":"foo<!--></xmp><!-->baz</xmp>",
 "output":[["Character", "foo<!-->"], ["EndTag", "xmp"], "ParseError", ["Comment", ""], ["Character", "baz"], ["EndTag", "xmp"]],
 "errors":[
-    { "code": "abrupt-comment", "line": 1, "col": 19 }
+    { "code": "abrupt-closing-of-comment", "line": 1, "col": 19 }
 ]},
 
 {"description":"Commented entities in RCDATA",

--- a/tokenizer/test1.test
+++ b/tokenizer/test1.test
@@ -117,7 +117,7 @@
 "input":"<!-->",
 "output":["ParseError", ["Comment", ""]],
 "errors":[
-    { "code": "abrupt-comment", "line": 1, "col": 5 }
+    { "code": "abrupt-closing-of-comment", "line": 1, "col": 5 }
 ]},
 
 
@@ -125,7 +125,7 @@
 "input":"<!--->",
 "output":["ParseError", ["Comment", ""]],
 "errors":[
-    { "code": "abrupt-comment", "line": 1, "col": 6 }
+    { "code": "abrupt-closing-of-comment", "line": 1, "col": 6 }
 ]},
 
 {"description":"Short comment three",

--- a/tree-construction/comments01.dat
+++ b/tree-construction/comments01.dat
@@ -106,7 +106,7 @@ FOO<!--->BAZ
 (1,3): expected-doctype-but-got-chars
 (1,9): incorrect-comment
 #new-errors
-(1:9) abrupt-comment
+(1:9) abrupt-closing-of-comment
 #document
 | <html>
 |   <head>
@@ -121,7 +121,7 @@ FOO<!-->BAZ
 (1,3): expected-doctype-but-got-chars
 (1,8): incorrect-comment
 #new-errors
-(1:8) abrupt-comment
+(1:8) abrupt-closing-of-comment
 #document
 | <html>
 |   <head>

--- a/tree-construction/tests1.dat
+++ b/tree-construction/tests1.dat
@@ -328,8 +328,8 @@ Line1<br>Line2<br>Line3<br>Line4
 (1,17): incorrect-comment
 (1,17): expected-closing-tag-but-got-eof
 #new-errors
-(1:5) abrupt-comment
-(1:17) abrupt-comment
+(1:5) abrupt-closing-of-comment
+(1:17) abrupt-closing-of-comment
 #document
 | <!--  -->
 | <html>


### PR DESCRIPTION
Closes HTMLParseErrorWG/meta#10
\cc @diervo 