### PR TITLE
Rename `abruption-of-tag-self-closure` error.

### DIFF
--- a/tokenizer/test2.test
+++ b/tokenizer/test2.test
@@ -164,7 +164,7 @@
 "input":"<h/a='b'>",
 "output":[["StartTag", "h", { "a":"b" }]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"Double-quoted attribute value",

--- a/tokenizer/test3.test
+++ b/tokenizer/test3.test
@@ -6590,7 +6590,7 @@
     { "code": "missing-whitespace-before-doctype-name", "line": 1, "col": 10 },
     { "code": "missing-whitespace-after-doctype-system-keyword", "line": 1, "col": 18 },
     { "code": "eof-in-doctype", "line": 1, "col": 20 }
-    
+
 ]},
 
 {"description":"<!DOCTYPEa SYSTEM\">",
@@ -10191,7 +10191,7 @@
 "input":"<a/\u0000>",
 "output":[["StartTag", "a", {"\uFFFD":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 },
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 },
     { "code": "unexpected-null-character", "line": 1, "col": 4 }
 ]},
 
@@ -10199,14 +10199,14 @@
 "input":"<a/\u0009>",
 "output":[["StartTag", "a", {}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/\\u000A>",
 "input":"<a/\u000A>",
 "output":[["StartTag", "a", {}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/\\u000B>",
@@ -10214,35 +10214,35 @@
 "output":[["StartTag", "a", {"\u000B":""}]],
 "errors":[
     { "code": "control-character-in-input-stream", "line": 1, "col": 4 },
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/\\u000C>",
 "input":"<a/\u000C>",
 "output":[["StartTag", "a", {}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/ >",
 "input":"<a/ >",
 "output":[["StartTag", "a", {}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/!>",
 "input":"<a/!>",
 "output":[["StartTag", "a", {"!":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/\">",
 "input":"<a/\">",
 "output":[["StartTag", "a", {"\"":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 },
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 },
     { "code": "unexpected-character-in-attribute-name", "line": 1, "col": 4 }
 ]},
 
@@ -10250,14 +10250,14 @@
 "input":"<a/&>",
 "output":[["StartTag", "a", {"&":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/'>",
 "input":"<a/'>",
 "output":[["StartTag", "a", {"'":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 },
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 },
     { "code": "unexpected-character-in-attribute-name", "line": 1, "col": 4 }
 ]},
 
@@ -10265,42 +10265,42 @@
 "input":"<a/->",
 "output":[["StartTag", "a", {"-":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a//>",
 "input":"<a//>",
 "output":[["StartTag", "a", {}, true]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/0>",
 "input":"<a/0>",
 "output":[["StartTag", "a", {"0":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/1>",
 "input":"<a/1>",
 "output":[["StartTag", "a", {"1":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/9>",
 "input":"<a/9>",
 "output":[["StartTag", "a", {"9":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/<>",
 "input":"<a/<>",
 "output":[["StartTag", "a", {"<":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 },
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 },
     { "code": "unexpected-character-in-attribute-name", "line": 1, "col": 4 }
 ]},
 
@@ -10308,7 +10308,7 @@
 "input":"<a/=>",
 "output":[["StartTag", "a", {"=":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 },
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 },
     { "code": "unexpected-equals-sign-before-attribute-name", "line": 1, "col": 4 }
 ]},
 
@@ -10320,91 +10320,91 @@
 "input":"<a/?>",
 "output":[["StartTag", "a", {"?":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/@>",
 "input":"<a/@>",
 "output":[["StartTag", "a", {"@":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/A>",
 "input":"<a/A>",
 "output":[["StartTag", "a", {"a":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/B>",
 "input":"<a/B>",
 "output":[["StartTag", "a", {"b":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/Y>",
 "input":"<a/Y>",
 "output":[["StartTag", "a", {"y":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/Z>",
 "input":"<a/Z>",
 "output":[["StartTag", "a", {"z":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/`>",
 "input":"<a/`>",
 "output":[["StartTag", "a", {"`":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/a>",
 "input":"<a/a>",
 "output":[["StartTag", "a", {"a":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/b>",
 "input":"<a/b>",
 "output":[["StartTag", "a", {"b":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/y>",
 "input":"<a/y>",
 "output":[["StartTag", "a", {"y":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/z>",
 "input":"<a/z>",
 "output":[["StartTag", "a", {"z":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/{>",
 "input":"<a/{>",
 "output":[["StartTag", "a", {"{":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a/\\uDBC0\\uDC00>",
 "input":"<a/\uDBC0\uDC00>",
 "output":[["StartTag", "a", {"\uDBC0\uDC00":""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 }
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 }
 ]},
 
 {"description":"<a0>",

--- a/tokenizer/test4.test
+++ b/tokenizer/test4.test
@@ -4,7 +4,7 @@
 "input":"<z/0  <>",
 "output":[["StartTag", "z", {"0": "", "<": ""}]],
 "errors":[
-    { "code": "abruption-of-tag-self-closure", "line": 1, "col": 4 },
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 4 },
     { "code": "unexpected-character-in-attribute-name", "line": 1, "col": 7 }
 ]},
 

--- a/tree-construction/scriptdata01.dat
+++ b/tree-construction/scriptdata01.dat
@@ -56,7 +56,7 @@ FOO<script></script/ >BAR
 (1,3): expected-doctype-but-got-chars
 (1,20): unexpected-character-after-solidus-in-tag
 #new-errors
-(1:21) abruption-of-tag-self-closure
+(1:21) unexpected-solidus-in-tag
 #document
 | <html>
 |   <head>

--- a/tree-construction/tests2.dat
+++ b/tree-construction/tests2.dat
@@ -750,9 +750,9 @@ x { content:"</style" } "
 (1,21): unexpected-character-after-solidus-in-tag
 (1,23): unexpected-character-after-solidus-in-tag
 #new-errors
-(1:20) abruption-of-tag-self-closure
-(1:22) abruption-of-tag-self-closure
-(1:24) abruption-of-tag-self-closure
+(1:20) unexpected-solidus-in-tag
+(1:22) unexpected-solidus-in-tag
+(1:24) unexpected-solidus-in-tag
 #document
 | <!DOCTYPE html>
 | <html>

--- a/tree-construction/tests26.dat
+++ b/tree-construction/tests26.dat
@@ -271,7 +271,7 @@
 (2,0): expected-closing-tag-but-got-eof
 #new-errors
 (1:11) unexpected-character-in-attribute-name
-(1:13) abruption-of-tag-self-closure
+(1:13) unexpected-solidus-in-tag
 #document
 | <html>
 |   <head>

--- a/tree-construction/webkit01.dat
+++ b/tree-construction/webkit01.dat
@@ -192,9 +192,9 @@ console.log("FOO<span>BAR</span>BAZ");
 (1,24): expected-doctype-but-got-start-tag
 (1,24): expected-closing-tag-but-got-eof
 #new-errors
-(1:8) abruption-of-tag-self-closure
-(1:9) abruption-of-tag-self-closure
-(1:17) abruption-of-tag-self-closure
+(1:8) unexpected-solidus-in-tag
+(1:9) unexpected-solidus-in-tag
+(1:17) unexpected-solidus-in-tag
 #document
 | <html>
 |   <head>


### PR DESCRIPTION
Closes HTMLParseErrorWG/meta#14.

\cc @diervo
The change to spec text itself will be made in context of error table PR.